### PR TITLE
ohpipeline: misc recipe improvements

### DIFF
--- a/recipes/ohpipeline/all/conandata.yml
+++ b/recipes/ohpipeline/all/conandata.yml
@@ -1,4 +1,13 @@
 sources:
   "1.139.1000":
-    url: "https://github.com/merakiacoustic/ohPipeline/archive/refs/heads/ohMediaPlayer_1.139.1000_meraki1.tar.gz"
-    sha256: "8bc1baaf6a7030ff572e67192f1ed672be531ebb1e36536a66c98ddce7e6425d"
+    source:
+      url: "https://github.com/openhome/ohPipeline/archive/refs/tags/ohMediaPlayer_1.139.1000.tar.gz"
+      sha256: "070eac6d974bbe520d0b292df1ca4a72160a2b607a60dabdaa0971c3ef96e5e4"
+    cmake:
+      url: "https://raw.githubusercontent.com/merakiacoustic/ohPipeline/ohMediaPlayer_1.139.1000_meraki1/CMakeLists.txt"
+      sha256: "ab40c930ff39da84ffdf66ab94aa18f8bdbf0dacf437ae51325aa2e55e2db5b2"
+patches:
+  "1.139.1000":
+    - patch_file: "patches/001-missing-include.patch"
+      patch_type: "portability"
+      patch_description: "Add a missing stdlib include"

--- a/recipes/ohpipeline/all/patches/001-missing-include.patch
+++ b/recipes/ohpipeline/all/patches/001-missing-include.patch
@@ -1,0 +1,10 @@
+--- a/OpenHome/Media/Protocol/ProtocolHls.cpp
++++ b/OpenHome/Media/Protocol/ProtocolHls.cpp
+@@ -18,6 +18,7 @@
+ #include <OpenHome/OsWrapper.h>
+ 
+ #include <algorithm>
++#include <limits>
+ 
+ namespace OpenHome {
+ namespace Media {


### PR DESCRIPTION
- Get the sources from the project itself and download only the CMakeLists.txt separately.
- Add the missing include patch.
- Set the package type to `static-library`.
- Bump dependency versions.
- Add VirtualBuildEnv for CMake tool_requires.
- Use the standard pattern for compiler and cppstd version checking.